### PR TITLE
Fix smoke tests

### DIFF
--- a/src/lsdb_rubin/tract_patch_search.py
+++ b/src/lsdb_rubin/tract_patch_search.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from lsdb.core.search.abstract_search import AbstractSearch
-from lsdb.core.search.box_search import box_filter
+from lsdb.core.search.region_search import box_filter
 from lsdb.types import HCCatalogTypeVar
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Address smoke test failures caused by changes in https://github.com/astronomy-commons/lsdb/pull/1034.